### PR TITLE
Switch Netlify build to pnpm

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   remote_images = ["https://source.unsplash.com/.*", "https://images.unsplash.com/.*", "https://ext.same-assets.com/.*", "https://ugc.same-assets.com/.*"]
 
 [build]
-  command = "bun run build"
+  command = "pnpm run build"
   publish = ".next"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- use pnpm as the build command for Netlify

## Testing
- `pnpm run build` *(fails: `next` not found)*
- `npx --yes netlify build` *(fails: project not linked)*

------
https://chatgpt.com/codex/tasks/task_e_685fa0d8b5c88325ad2218ef4f25f39a