### PR TITLE
Add custom not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { Navbar } from "@/components/navigation/navbar";
+import { CursorFollower } from "@/components/cursor/cursor-follower";
+import { WebGLFallbackBackground } from "@/components/background/webgl-fallback-background";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="page-wrapper">
+      <CursorFollower />
+      <WebGLFallbackBackground />
+      <Navbar />
+      <main className="w-full max-w-screen-xl mx-auto py-24 px-6 text-center">
+        <h1 className="text-4xl md:text-6xl font-bold mb-6">
+          Страница не найдена
+        </h1>
+        <p className="text-lg mb-8">
+          К сожалению, запрашиваемая страница не существует.
+        </p>
+        <Button asChild variant="secondary">
+          <Link href="/" data-cursor-hover>
+            Вернуться на главную
+          </Link>
+        </Button>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `src/app/not-found.tsx` to render a user-friendly 404 page

## Testing
- `bun x biome lint --write src/app/not-found.tsx`
- `bun x tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685fe56a8d04832587bf79aa40a239d9