### PR TITLE
Compile service worker using TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+public/sw.js
+public/tsconfig.sw.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "build:sw": "tsc -p tsconfig.sw.json",
+    "prebuild": "pnpm run build:sw",
     "dev": "next dev -H 0.0.0.0 --turbopack",
     "format": "bunx biome format --write",
     "lint": "bunx biome lint --write && bunx tsc --noEmit",

--- a/tsconfig.sw.json
+++ b/tsconfig.sw.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "incremental": false,
+    "outDir": "public",
+    "lib": ["webworker", "esnext"],
+    "isolatedModules": false
+  },
+  "include": ["src/sw.ts"]
+}


### PR DESCRIPTION
## Summary
- convert `public/sw.js` to `src/sw.ts`
- compile the service worker in a new `build:sw` script
- run the service worker build automatically before `next build`
- ignore generated service worker files

## Testing
- `pnpm run build:sw`

------
https://chatgpt.com/codex/tasks/task_e_685fe56da8fc8325a5f7120ad6475fe2